### PR TITLE
增加 places 的 callback 傳入參數

### DIFF
--- a/jquery.tinyMap.js
+++ b/jquery.tinyMap.js
@@ -1479,7 +1479,7 @@ console.log(renderOpts);
                             });
                         }
                         if (request.hasOwnProperty('callback') && 'function' === typeof request.callback) {
-                            request.callback.call(results);
+                            request.callback.call(results, placesService);
                         }
                     }
                 });


### PR DESCRIPTION
places: { callback: function () { console.log(this); } } 改進為 places: { callback: function (service) { console.log(this); } }

之後可直接在 callback 中調用 service.getDetails({ placeId: marker.place_id }, function (result, status) { ... }); 取得地點的詳細訊息。